### PR TITLE
Move `electron-releases` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
   "devDependencies": {
     "ava": "^0.18.2",
     "codecov": "^2.1.0",
+    "electron-releases": "^2.1.0",
     "nyc": "^10.2.0",
     "request": "^2.79.0",
     "shelljs": "^0.7.6"
-  },
-  "dependencies": {
-    "electron-releases": "^2.1.0"
   }
 }


### PR DESCRIPTION
Hi,

`electron-releases` package is only required for build/update process.
This will save around 9 MB space on end user harddisk.