### PR TITLE
deps: ⬆️ electron-releases@^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "ava": "^0.18.2",
     "codecov": "^2.1.0",
-    "electron-releases": "^2.1.0",
+    "electron-releases": "^3.1.0",
     "nyc": "^10.2.0",
     "request": "^2.79.0",
     "shelljs": "^0.7.6"


### PR DESCRIPTION
We've pushed a semver-major change to `electron-releases`, which means that new release info is no longer provided on the `2.x` line. The change to the data structure doesn't affect `electron-to-chromium`, but the dependency needs to be updated to get the new release info. See https://github.com/electron/releases/pull/27 for more information.