### PR TITLE
feat: Use Dependabot to check for Node updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Read the Dependabot documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Europe/Amsterdam


### PR DESCRIPTION
## Changes:

- Use Dependabot to check for node package updates

## Context:

I noticed some packages are out of date, and could use updates.
Dependabot can help with managing your development dependencies.

## What will happen when you merge this pull:

This commits enables Dependabot in this repository.
It will check for Node updates each working day (Monday trough Friday).
It will run the check at 8 o'clock Dutch time.

Dependabot will use the default labels: "dependencies".
You don't need to add any labels to the repository, Dependabot will manage those automatically.

When you merge this pull request, Dependabot will do a run right away.
Afterwards it will follow the schedule.

## Documentation for Dependabot configuration:

For more information on how to configure Dependabot to your liking: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates