### PR TITLE
test: Drop Node 8 and 13, but add 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
-  - "13"
+  - "14"
 after_script: npm run report


### PR DESCRIPTION
Drop Node version 8 and 13 from test matrix, they are no longer supported by Node.js
Add current Node.js 14 to testing matrix.

See https://nodejs.org/en/about/releases/ for the Node.js support schedule.