### PR TITLE
Create GitHub Action + let Dependabot update the action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       interval: daily
       time: '08:00'
       timezone: Europe/Amsterdam
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Europe/Amsterdam

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean install of Node.js dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
## Changes:

- Create GitHub Action that makes a build and runs the tests on each pull request.
- Let Dependabot check for GitHub Action updates.

## Context:

As discussed in #39, you wanted a GitHub Action that only runs on pulls.
It uses the same test matrix as what you use with Travis CI.

https://github.com/Kilian/electron-to-chromium/blob/92587071ac118441bbf731dbf468113f6d3a1051/.travis.yml#L2-L5

Closes #39