### PR TITLE
fix: Fix broken GitHub Action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches: master
 
 jobs:
   build:


### PR DESCRIPTION
## Changes:

- Replace `$default-branch` token with `master`.

## Context:

The `$default-branch` name variable is only used by GitHub internally, it's not meant to be a user-facing variable.

This means that if you ever change the branch name, you will need to change it in the Action configuration as well.