### PR TITLE
Run tests on Node 15

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes:

- Add Node 15 to test matrix

## Context:

Node.js has a new current release, version 15.
I don't know if you care about/support the latest current release, or if you only support LTS releases.
Feel free to close this if you don't care about Node 15. 😉 