### PR TITLE
Update Node.js test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
## Changes:

- Drop Node 10 (Reached end-of-life EOL, Node themselves no longer support this version)
- Drop Node 15 (Also EOL)
- Add Node 16 (Current version, will become LTS later)

## Context:

I noticed we could drop some EOL versions of Node, and prepare for the future LTS of Node.
Feel free to use a suggestion in the PR review screen to adjust the matrix to your liking.

See https://nodejs.org/en/about/releases/ for the official support schedule from Node.js themselves.