### PR TITLE
Update setup-node and enable npm cache

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
## Changes:

- Updates `action/setup-node` from `2.1.5` to `2.2.0`
- Enable the built-in cache for npm packages

## Context:

The action now comes with built-in functionality to cache the npm packages.
This might speed up the execution of the action. 😉 

Release notes for this update: https://github.com/actions/setup-node/releases/tag/v2.2.0